### PR TITLE
Fixed link to Nerfies website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Nerfies
 
-This is the repository that contains source code for the [Nerfies website](nerfies.github.io).
+This is the repository that contains source code for the [Nerfies website](https://nerfies.github.io).
 
 If you find Nerfies useful for your work please cite:
 ```


### PR DESCRIPTION
The link is not clickable on GitHub, because it is missing the prefix.